### PR TITLE
Add mobile arrangement to InvoiceInfoModal

### DIFF
--- a/src/Kompo/InvoiceInfoModal.php
+++ b/src/Kompo/InvoiceInfoModal.php
@@ -8,7 +8,7 @@ use Condoedge\Utils\Kompo\Common\Form;
 
 class InvoiceInfoModal extends Form
 {
-    public $class = 'overflow-y-auto mini-scroll max-w-lg';
+    public $class = 'overflow-y-auto mini-scroll max-w-lg sisc-inv-modal';
     public $style = 'max-height: 95vh; width: 98vw;';
 
     public $model = InvoiceModel::class;
@@ -23,6 +23,12 @@ class InvoiceInfoModal extends Form
     public function render()
     {
         return _Rows(
+            // Phone-only header (back arrow + title). Hidden on desktop via CSS; the Kompo close X is hidden on mobile instead.
+            _FlexBetween(
+                _Link()->icon('arrow-left')->closeModal()->class('text-greendark text-2xl'),
+                _Html('finance.invoice')->class('font-bold text-greendark text-lg'),
+                _Html('')->class('w-6'),
+            )->class('sisc-inv-header items-center mb-2'),
             _FlexEnd(
                 $this->model->invoice_status_id->pill(),
             ),
@@ -32,9 +38,14 @@ class InvoiceInfoModal extends Form
                 _Html(__('finance.issued-date', ['date' => $this->model->invoice_date->format('Y-m-d')]))->class('text-level1 mb-3'),
                 _FinanceCurrency($this->model->invoice_total_amount)->class('text-3xl font-bold mb-4'),
                 _FlexCenter(
-                    _ButtonOutlined('finance.send-receipt')->class('!py-1')->icon('receipt'),
+                    // Desktop labels
+                    _ButtonOutlined('finance.send-receipt')->class('!py-1 sisc-inv-bd')->icon('receipt'),
                     _ButtonOutlined('finance.send-invoice')
-                        ->selfPost('sendInvoice')->alert('finance-invoice-sent')->class('!py-1')->icon('receipt'),
+                        ->selfPost('sendInvoice')->alert('finance-invoice-sent')->class('!py-1 sisc-inv-bd')->icon('receipt'),
+                    // Phone-only short labels (toggled by CSS; desktop variants stay untouched)
+                    _ButtonOutlined('finance.receipt')->class('!py-1 sisc-inv-bm')->icon('receipt'),
+                    _ButtonOutlined('finance.send')
+                        ->selfPost('sendInvoice')->alert('finance-invoice-sent')->class('!py-1 sisc-inv-bm')->icon('send-2'),
                 )->class('gap-4'),
             )->class('text-center border-b border-gray-200 pb-4 mb-4'),
             _Rows(
@@ -46,15 +57,15 @@ class InvoiceInfoModal extends Form
                         _Html($this->team->team_name),
                         _TextSm($this->team->getFirstValidAddressLabel()),
                     )
-                )->class('text-level1'),
+                )->class('text-level1 sisc-inv-party'),
                 _Rows(
                     _Html('finance.to')->class('font-semibold text-black'),
                     _Rows(
                         _Html($this->model->customer->name),
                         // _TextSm($this->model->customer->getFirstValidAddressLabel()),
                     )
-                )->class('text-level1'),
-            )->class('gap-3 mb-6'),
+                )->class('text-level1 sisc-inv-party'),
+            )->class('gap-3 mb-6 sisc-inv-parties'),
             $this->latestPaymentTries(),
             _Tabs(
                 _Tab(
@@ -82,7 +93,7 @@ class InvoiceInfoModal extends Form
                         _FlexBetween(
                             _Html('finance.balance'),
                             _FinanceCurrency($this->model->invoice_due_amount)->class('font-semibold'),
-                        ),
+                        )->class('sisc-inv-balance'),
                     )->class('gap-1 p-6'),
                 )->label('finance.summary'),
                 _Tab(
@@ -113,8 +124,15 @@ class InvoiceInfoModal extends Form
                 )->label('finance.payments'),
             )->class('mb-4'),
             !$this->model->invoice_status_id?->canBePaid() ? null :
-                _Button('finance.pay-invoice')->selfGet('getInvoicePayModal')->inModal()->class('mb-4'),
+                _Button('finance.pay-invoice')->attr(['data-amount' => $this->payAmountLabel()])
+                    ->selfGet('getInvoicePayModal')->inModal()->class('mb-4 sisc-inv-pay'),
         )->class('p-6');
+    }
+
+    /** Plain due-amount label appended after the pay button on phones (via CSS ::after). */
+    protected function payAmountLabel(): string
+    {
+        return ' · ' . number_format($this->model->invoice_due_amount->toFloat(), 2, ',', ' ') . ' $';
     }
 
     public function latestPaymentTries()


### PR DESCRIPTION
## Summary
Phone-only layout for the invoice detail modal (`InvoiceInfoModal`). Desktop rendering is untouched — all changes are carried by neutral hook classes (`sisc-inv-*`) and dual-rendered button variants that the consuming app toggles with CSS media queries.

## Changes
- **Mobile header**: back-arrow + "Facture" title at the top (`sisc-inv-header`); the modal gets a `sisc-inv-modal` class so the consumer can hide the Kompo close X on mobile.
- **Buttons**: dual-rendered — long *Send receipt / Send invoice* labels for desktop (`sisc-inv-bd`), short *Reçu / Envoyer* labels for phones (`sisc-inv-bm`).
- **From / To**: side-by-side blocks on mobile (`sisc-inv-party` / `sisc-inv-parties`).
- **Balance due**: emphasised row (`sisc-inv-balance`).
- **Pay button**: due amount appended via `data-amount` + `sisc-inv-pay` (CSS `::after`); new `payAmountLabel()` helper.

## Notes
- **No CSS shipped**: the package ships no stylesheet, so the `sisc-inv-*` classes are hooks styled by the consumer (matching the package's existing pattern). The `sisc-` prefix is consumer-specific and can be renamed later in a coordinated change.
- **No translations added**: the invoice modal's labels (`finance.send-receipt`, `finance.invoice-number`, `finance.balance`, and the new `finance.invoice` / `finance.receipt` / `finance.send`) are provided by the consumer, like the rest of the modal.
- Desktop layout is unchanged; only hook classes and phone-only variants were added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)