### PR TITLE
fix: align permission keys with SISC #1330 (OwnExpenses->my_expenses, PaymentProviders->payment_providers)

### DIFF
--- a/src/Kompo/ExpenseReports/UserExpenseReportTable.php
+++ b/src/Kompo/ExpenseReports/UserExpenseReportTable.php
@@ -9,14 +9,14 @@ class UserExpenseReportTable extends ExpenseReportsTable
     public $id = 'user-expense-report-table';
     protected $asManager = false;
 
-    public $permissionKey = 'OwnExpenses';
+    public $permissionKey = 'my_expenses';
 
     protected function header()
     {
         return _FlexBetween(
             _Html('finance-my-expense-reports')->class('font-semibold text-2xl'),
             _Button('finance-create-expense-report')
-                ->checkAuthWrite('OwnExpenses')
+                ->checkAuthWrite('my_expenses')
                 ->selfGet('getExpenseReportModal')
                 ->inModal(),
         )->class('mb-6');
@@ -42,7 +42,7 @@ class UserExpenseReportTable extends ExpenseReportsTable
 
     protected function canOpenModal()
     {
-        return auth()->user()->hasPermission('OwnExpenses');
+        return auth()->user()->hasPermission('my_expenses');
     }
 
     public function getExpenseReportModal($expenseReportId = null)

--- a/src/Kompo/Settings/PaymentProvidersSettings.php
+++ b/src/Kompo/Settings/PaymentProvidersSettings.php
@@ -23,7 +23,7 @@ class PaymentProvidersSettings extends Form
 {
     public $class = 'space-y-6';
 
-    public $permissionKey = 'PaymentProviders';
+    public $permissionKey = 'payment_providers';
 
     protected int $teamId;
 


### PR DESCRIPTION
## What
Rename two stale permission keys to match the SISC #1330 permission reorganization:
- `OwnExpenses` → `my_expenses` (`UserExpenseReportTable`: `$permissionKey`, create-expense button, `canOpenModal`)
- `PaymentProviders` → `payment_providers` (`PaymentProvidersSettings`: `$permissionKey`)

## Why
SISC renamed these keys (rename migration + new permission seeder). The package kept the old PascalCase keys, so the checks resolved to false for roles granted the new keys — e.g. the "create expense report" button stayed hidden and the payment-providers settings page was mis-gated.

## Note
Keys are now SISC-aligned. If other consumers rely on the old keys, this is a breaking rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)